### PR TITLE
Relaxed device serial validation

### DIFF
--- a/oath.go
+++ b/oath.go
@@ -10,7 +10,7 @@ import (
 )
 
 // deviceSerialPattern ensures the given Yubikey device serial is either empty string or at least 8 digits
-var deviceSerialPattern = regexp.MustCompile(`^$|^\d{8,}$`)
+var deviceSerialPattern = regexp.MustCompile(`^$|^\d+$`)
 
 // OathAccounts represents a the main functionality of Yubikey OATH accounts.
 type OathAccounts struct {


### PR DESCRIPTION
Device serial number validation pattern is too strict for older devices. My Yubikey 4 supports TOTP however its SN has a 7 only digits. I suggest completely relaxing the rule as a simple fixup.

I can imagine device SN validation could be removed altogether at the cost of a BC break (`ErrDeviceSerial` removal).
